### PR TITLE
Update db engine version with prefix

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -13,7 +13,7 @@ resource "aws_db_instance" "ga_mysql" {
   db_subnet_group_name            = aws_db_subnet_group.data.name
   enabled_cloudwatch_logs_exports = ["audit", "general", "error", "slowquery"]
   engine                          = "mysql"
-  engine_version                  = "8.0.35"
+  engine_version                  = "8.0"
   identifier                      = "ga-db-${var.BRANCH_NAME}"
   instance_class                  = var.DB_INSTANCE_CLASS
   monitoring_interval             = 5


### PR DESCRIPTION
Use prefix only ->

(Optional) The engine version to use. If auto_minor_version_upgrade is enabled, you can provide a prefix of the version such as 8.0 (for 8.0.36).